### PR TITLE
Get mutable branch passing AppVeyor

### DIFF
--- a/tst/extreme/attr.tst
+++ b/tst/extreme/attr.tst
@@ -23,9 +23,6 @@ gap> ReducedDigraph(gr);
 
 #  DigraphSymmetricClosure 1
 # For a digraph with lots of edges: digraphs-lib/extreme.d6.gz
-gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
->                                     "/digraphs-lib/extreme.d6.gz"), 1);
-<immutable digraph with 5000 vertices, 4211332 edges>
 gap> DigraphSymmetricClosure(gr);
 <immutable digraph with 5000 vertices, 7713076 edges>
 gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),


### PR DESCRIPTION
For some reason AppVeyor is failing to re-read in a digraph in `extreme/attr.tst`. This is probably to do with IO and Windows not being the best of friends. However, since the digraph has already been read in and saved, then we can just re-use it in the later tests rather than reading it again. This seems to stop AppVeyor from complaining.

I think the original purpose of re-reading the digraph was to have each 'chunk' of the test file be able to run independently, for my package profiler thing that I abandoned. So the re-read was redundant anyway.

Hopefully this fixes things.